### PR TITLE
Simplified a bit and removed unnecessary c_rehash.

### DIFF
--- a/bin/openssl-osx-ca
+++ b/bin/openssl-osx-ca
@@ -3,15 +3,10 @@
 set -e
 
 openssl=$(brew list openssl | grep bin/openssl | head -n 1)
-c_rehash=$(brew list openssl | grep bin/c_rehash | head -n 1)
 openssldir=$($openssl version -d | cut -d '"' -f 2)
 
-tmpdir=$(mktemp -d -t openssl-osx-ca)
-certs="${tmpdir}/cert.pem"
+certs="$(mktemp -t openssl-osx-ca)"
 security find-certificate -a -p /Library/Keychains/System.keychain > $certs
 security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> $certs
-$c_rehash $tmpdir > /dev/null
 
-# XXX: I don't think this is atomic on OSX, but it's as close as we're going to
-# get without a lot more work.
-mv -f ${tmpdir}/* ${openssldir}/
+mv -f ${certs} ${openssldir}/cert.pem


### PR DESCRIPTION
Tested by rebuilding ruby-2.0.0-p0, installing rails, updating bundler to 1.3.0 and created a rails app to try it out.

All worked fine `dtrace` showed me that whenever a HTTPS url is accessed `/usr/local/etc/openssl/cert.pem` is opened.

:thumbsup:
