### PR TITLE
Prevent c_rehash from reading directories as args

### DIFF
--- a/bin/openssl-osx-ca
+++ b/bin/openssl-osx-ca
@@ -36,7 +36,7 @@ d2=$($openssl md5 ${tmpdir}/cert.pem | awk '{print $2}')
 if [[ "${d1}" = "${d2}" ]]; then
 	logger -t "$(basename $0)" "${openssldir}/cert.pem up to date"
 else
-	if ! $c_rehash $tmpdir > /dev/null; then
+	if ! $c_rehash -- $tmpdir > /dev/null; then
 		logger -t "$(basename $0)" "${openssldir}/cert.pem updated failed, see cron"
 
 		echo "rehash failed to verify, something is wrong"


### PR DESCRIPTION
`c_rehash` chokes on some tmpdir names. For example:

```sh
$ /usr/local/Cellar/openssl/1.0.2/bin/c_rehash  /var/folders/dx/497n51w97pn8jtlp556yjj540001tt/T/openssl-osx-ca.02uEvIJl
Usage error; try -help.
```

Separating the file argument from the command by a double-hyphen solves the issue.

```sh
$ /usr/local/Cellar/openssl/1.0.2/bin/c_rehash -- /var/folders/dx/497n51w97pn8jtlp556yjj540001tt/T/openssl-osx-ca.02uEvIJl
Doing /var/folders/dx/497n51w97pn8jtlp556yjj540001tt/T/openssl-osx-ca.02uEvIJl
```