### PR TITLE
Also search login keychain for certs

### DIFF
--- a/bin/openssl-osx-ca
+++ b/bin/openssl-osx-ca
@@ -29,6 +29,7 @@ tmpdir=$(/usr/bin/mktemp -d -t openssl_osx_ca)
 certs="${tmpdir}/cert.pem"
 security find-certificate -a -p /Library/Keychains/System.keychain > $certs
 security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> $certs
+security find-certificate -a -p ~/Library/Keychains/login.keychain >> $certs
 
 d1=$($openssl md5 ${openssldir}/cert.pem | awk '{print $2}')
 d2=$($openssl md5 ${tmpdir}/cert.pem | awk '{print $2}')


### PR DESCRIPTION
Some certs (especially manually imported ones) get installed in the login keychain. In order to make sure those get synced, this script should pull them in too.