### PR TITLE
Call brew using variable

### DIFF
--- a/bin/openssl-osx-ca
+++ b/bin/openssl-osx-ca
@@ -83,7 +83,7 @@ genbundle() {
 	rm -r "${tmpdir}"
 }
 
-impls="$(brew list | grep -E '^((libre|open)ssl(@[0-9\.]+)?)$')"
+impls="$($brew list | grep -E '^((libre|open)ssl(@[0-9\.]+)?)$')"
 for sslimpl in $impls; do
 	genbundle $sslimpl
 done


### PR DESCRIPTION
On line 86 brew is called directly, not using the argument passed in.  This breaks it if one uses cron for scheduling.