### PR TITLE
Fix error calling brew list on brew >= 2.7.0

### DIFF
--- a/bin/openssl-osx-ca
+++ b/bin/openssl-osx-ca
@@ -42,7 +42,7 @@ genbundle() {
 	local sslimpl="$1"
 	local certpem="$2"
 
-	local list=$("$brew" list $sslimpl 2>/dev/null)
+	local list=$("$brew" list --formula $sslimpl 2>/dev/null)
 	[[ -z $list ]] && continue
 
 	local openssl=$(echo "$list" | grep bin/openssl | head -n 1)
@@ -76,7 +76,7 @@ certs="${tmpdir}/cert.pem"
 "${osx_ca_certs}" > "${certs}"
 
 exitcode=0
-impls=($("$brew" list | grep -E '^((libre|open)ssl(@[0-9\.]+)?)$'))
+impls=($("$brew" list --formula | grep -E '^((libre|open)ssl(@[0-9\.]+)?)$'))
 for sslimpl in "${impls[@]}"; do
 	genbundle "${sslimpl}" "${certs}"
 	exitcode=$(( $exitcode + $? ))


### PR DESCRIPTION
Firstly thank you for making a really useful tool! 😄  I've used it for ages and prior to it I was having to do similar steps manually whenever OpenSSL updated!
I found a small compatibility issue with Brew >= 2.7.0

Brew 2.6.0 [deprecated calling `brew list` without arugments without a TTY](https://github.com/Homebrew/brew/pull/9357).

Brew 2.7.0 [removed it](https://github.com/Homebrew/brew/commit/f15c4183e0b3ecf7d639bae3169911c647863dce).

This results in the following error running `openssl-osx-ca` on Brew >= 2.7.0:

```
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
```

This is a small change that adds the `--formula` flag to make `openssl-osx-ca` compatible with Brew 2.7.0.