### PR TITLE
Chore: Update documentation for ARM based Macs for certs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The keychains exported to the CA bundle by default are:
  * login.keychain (if run as a user)
 
 The installed CA pem file will be made available through the default X.509 store
-path, commonly `/usr/local/etc/openssl/cert.pem`.
+path. This is commonly found in either: `/usr/local/etc/openssl/cert.pem` (for
+Intel based Macs) or `/opt/homebrew/etc/openssl/cert.pem` (for M1/ARM based Macs).
 
 ## Installation
 


### PR DESCRIPTION
Due to the brew prefix being different based on whether the user is
using an Intel based mac or a M1 (ARM) based mac, the initial directory
where the brew packages are is different.

This takes into account to list both possible locations so that if
the user is ever setting the `SSL_CERT_FILE`, they know where to look.