### PR TITLE
Changes move command to explicitly reference file names

### DIFF
--- a/bin/openssl-osx-ca
+++ b/bin/openssl-osx-ca
@@ -60,7 +60,7 @@ genbundle() {
 		logger -t "$(basename $0)" "${openssldir}/cert.pem up to date"
 	else
 		cp "${certpem}" "${openssldir}/cert.pem.new"
-		mv -f "${openssldir}/cert.pem"{.new,}
+		mv -f "${openssldir}/cert.pem.new" "${openssldir}/cert.pem"
 
 		logger -t "$(basename $0)" "${openssldir}/cert.pem updated"
 	fi


### PR DESCRIPTION
Unless I use the explicit `mv` command with both paths, I get a zero byte `cert.pem` file